### PR TITLE
Mobile header

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS, WEIGHTS } from '../../constants';
+import { COLORS, WEIGHTS, QUERIES } from '../../constants';
 import Logo from '../Logo';
 import SuperHeader from '../SuperHeader';
 import MobileMenu from '../MobileMenu';
@@ -46,28 +46,32 @@ const MainHeader = styled.div`
   padding: 18px 32px;
   height: 72px;
   border-bottom: 1px solid ${COLORS.gray[300]};
+
+  @media ${QUERIES["tabletAndSmaller"]} {
+    border-top: 4px solid ${COLORS.gray[900]};
+  }
 `;
 
 const Nav = styled.nav`
-  display: flex;
-  gap: 48px;
-  margin: 0px 48px;
+display: flex;
+gap: 48px;
+margin: 0px 48px;
 `;
 
 const Side = styled.div`
-  flex: 1;
+flex: 1;
 `;
 
 const NavLink = styled.a`
-  font-size: 1.125rem;
-  text-transform: uppercase;
-  text-decoration: none;
-  color: ${COLORS.gray[900]};
-  font-weight: ${WEIGHTS.medium};
+font - size: 1.125rem;
+text - transform: uppercase;
+text - decoration: none;
+color: ${COLORS.gray[900]};
+font - weight: ${WEIGHTS.medium};
 
-  &:first-of-type {
-    color: ${COLORS.secondary};
-  }
+  &: first - of - type {
+  color: ${COLORS.secondary};
+}
 `;
 
 export default Header;

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -47,8 +47,12 @@ const MainHeader = styled.div`
   height: 72px;
   border-bottom: 1px solid ${COLORS.gray[300]};
 
-  @media ${QUERIES["tabletAndSmaller"]} {
+  @media ${QUERIES.tabletAndSmaller} {
     border-top: 4px solid ${COLORS.gray[900]};
+  }
+
+  @media ${QUERIES.phoneAndSmaller} {
+    padding: 18px 16px;
   }
 `;
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -42,7 +42,7 @@ const Header = () => {
         <UnstyledButton>
           <Icon id="search" strokeWidth={2} />
         </UnstyledButton>
-        <UnstyledButton>
+        <UnstyledButton onClick={() => setShowMobileMenu(true)}>
           <Icon id="menu" strokeWidth={2} />
         </UnstyledButton>
       </SmallScreenMainHeader>

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -5,6 +5,8 @@ import { COLORS, WEIGHTS, QUERIES } from '../../constants';
 import Logo from '../Logo';
 import SuperHeader from '../SuperHeader';
 import MobileMenu from '../MobileMenu';
+import UnstyledButton from '../UnstyledButton';
+import Icon from '../Icon';
 
 const Header = () => {
   const [showMobileMenu, setShowMobileMenu] = React.useState(false);
@@ -32,6 +34,19 @@ const Header = () => {
         <Side />
       </MainHeader>
 
+      <SmallScreenMainHeader>
+        <Logo />
+        <UnstyledButton>
+          <Icon id="shopping-bag" strokeWidth={2} />
+        </UnstyledButton>
+        <UnstyledButton>
+          <Icon id="search" strokeWidth={2} />
+        </UnstyledButton>
+        <UnstyledButton>
+          <Icon id="menu" strokeWidth={2} />
+        </UnstyledButton>
+      </SmallScreenMainHeader>
+
       <MobileMenu
         isOpen={showMobileMenu}
         onDismiss={() => setShowMobileMenu(false)}
@@ -48,7 +63,21 @@ const MainHeader = styled.div`
   border-bottom: 1px solid ${COLORS.gray[300]};
 
   @media ${QUERIES.tabletAndSmaller} {
-    border-top: 4px solid ${COLORS.gray[900]};
+    display: none;
+  }
+`;
+
+const SmallScreenMainHeader = styled.div`
+  display: none;
+
+  padding: 18px 32px;
+  height: 72px;
+  border-top: 4px solid ${COLORS.gray[900]};
+  border-bottom: 1px solid ${COLORS.gray[300]};
+
+  @media ${QUERIES.tabletAndSmaller} {
+    display: flex;
+    gap: 4vw;
   }
 
   @media ${QUERIES.phoneAndSmaller} {

--- a/src/components/Logo/Logo.js
+++ b/src/components/Logo/Logo.js
@@ -1,6 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/macro';
-import { WEIGHTS } from '../../constants';
+import { WEIGHTS, QUERIES } from '../../constants';
 
 const Logo = (props) => {
   return (
@@ -13,6 +13,10 @@ const Logo = (props) => {
 const Link = styled.a`
   text-decoration: none;
   color: inherit;
+
+  @media ${QUERIES.tabletAndSmaller} {
+    margin-right: auto;
+  }
 `;
 
 const Wrapper = styled.h1`

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -13,23 +13,44 @@ const MobileMenu = ({ isOpen, onDismiss }) => {
   }
 
   return (
-    <div>
-      <button onClick={onDismiss}>Dismiss menu</button>
-      <nav>
-        <a href="/sale">Sale</a>
-        <a href="/new">New&nbsp;Releases</a>
-        <a href="/men">Men</a>
-        <a href="/women">Women</a>
-        <a href="/kids">Kids</a>
-        <a href="/collections">Collections</a>
-      </nav>
-      <footer>
-        <a href="/terms">Terms and Conditions</a>
-        <a href="/privacy">Privacy Policy</a>
-        <a href="/contact">Contact Us</a>
-      </footer>
-    </div>
+    <DialogOverlay>
+      <DialogContent>
+        <DialogLayout>
+          <button onClick={onDismiss}>Dismiss menu</button>
+          <DialogNav>
+            <a href="/sale">Sale</a>
+            <a href="/new">New&nbsp;Releases</a>
+            <a href="/men">Men</a>
+            <a href="/women">Women</a>
+            <a href="/kids">Kids</a>
+            <a href="/collections">Collections</a>
+          </DialogNav>
+          <DialogFooter>
+            <a href="/terms">Terms and Conditions</a>
+            <a href="/privacy">Privacy Policy</a>
+            <a href="/contact">Contact Us</a>
+          </DialogFooter>
+        </DialogLayout>
+      </DialogContent>
+    </DialogOverlay >
   );
 };
+
+const DialogLayout = styled.div`
+  height: 100%;
+  background-color: white;
+  display: flex;
+  flex-direction: column;
+`;
+
+const DialogNav = styled.nav`
+  display: flex;
+  flex-direction: column;
+`;
+
+const DialogFooter = styled.footer`
+  display: flex;
+  flex-direction: column;
+`;
 
 export default MobileMenu;

--- a/src/components/SuperHeader/SuperHeader.js
+++ b/src/components/SuperHeader/SuperHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS } from '../../constants';
+import { COLORS, QUERIES } from '../../constants';
 
 import SearchInput from '../SearchInput';
 import UnstyledButton from '../UnstyledButton';
@@ -32,6 +32,10 @@ const Wrapper = styled.div`
   height: 40px;
   padding-left: 32px;
   padding-right: 32px;
+
+  @media ${QUERIES["tabletAndSmaller"]} {
+    display: none;
+  }
 `;
 
 const MarketingMessage = styled.span`


### PR DESCRIPTION
Submission for [Exercise 2](https://github.com/VrsajkovIvan33/sole-and-ankle-revisited?tab=readme-ov-file#exercise-2-mobile-header).

- Hide the super header.
- Add top border on header.
- Create separate header component that shows up when screen is tablet or phone.
- Fluid spacing between elements in new header.

Unable to complete moble menu component. It keeps rendering _under_ the rest of the page, even though it should be above according to the DOM order and stacking context. Will add corrections after watching the solution video.