### PR TITLE
Main view

### DIFF
--- a/src/components/App/App.js
+++ b/src/components/App/App.js
@@ -4,6 +4,8 @@ import styled from 'styled-components/macro';
 import Header from '../Header';
 import ShoeIndex from '../ShoeIndex';
 
+import { QUERIES } from '../../constants';
+
 const App = () => {
   const [sortId, setSortId] = React.useState('newest');
 
@@ -19,6 +21,10 @@ const App = () => {
 
 const Main = styled.main`
   padding: 64px 32px;
+
+  @media ${QUERIES.tabletAndSmaller} {
+    padding: 48px 16px;
+  }
 `;
 
 export default App;

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -5,7 +5,7 @@ import { COLORS, WEIGHTS } from '../../constants';
 
 import Icon from '../Icon';
 
-const Select = ({ label, value, children, ...delegated }) => {
+const Select = ({ label, value, children, className, ...delegated }) => {
   const childArray = React.Children.toArray(children);
   const selectedChild = childArray.find(
     (child) => child.props.value === value
@@ -14,7 +14,7 @@ const Select = ({ label, value, children, ...delegated }) => {
   const displayedValue = selectedChild.props.children;
 
   return (
-    <Wrapper>
+    <Wrapper className={className}>
       <VisibleLabel>{label}</VisibleLabel>
 
       <SelectWrapper>

--- a/src/components/ShoeIndex/ShoeIndex.js
+++ b/src/components/ShoeIndex/ShoeIndex.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { WEIGHTS } from '../../constants';
+import { WEIGHTS, QUERIES } from '../../constants';
 
 import Breadcrumbs from '../Breadcrumbs';
 import Select from '../Select';
@@ -12,7 +12,7 @@ import ShoeGrid from '../ShoeGrid';
 const ShoeIndex = ({ sortId, setSortId }) => {
   return (
     <Wrapper>
-      <MainColumn>
+      <Main>
         <Header>
           <Title>Running</Title>
           <Select
@@ -26,8 +26,8 @@ const ShoeIndex = ({ sortId, setSortId }) => {
         </Header>
         <Spacer size={32} />
         <ShoeGrid />
-      </MainColumn>
-      <LeftColumn>
+      </Main>
+      <Nav>
         <Breadcrumbs>
           <Breadcrumbs.Crumb href="/">Home</Breadcrumbs.Crumb>
           <Breadcrumbs.Crumb href="/sale">Sale</Breadcrumbs.Crumb>
@@ -35,9 +35,11 @@ const ShoeIndex = ({ sortId, setSortId }) => {
             Shoes
           </Breadcrumbs.Crumb>
         </Breadcrumbs>
-        <Spacer size={42} />
-        <ShoeSidebar />
-      </LeftColumn>
+        <AdditionalNavigation>
+          <Spacer size={42} />
+          <ShoeSidebar />
+        </AdditionalNavigation>
+      </Nav>
     </Wrapper>
   );
 };
@@ -47,13 +49,22 @@ const Wrapper = styled.div`
   flex-direction: row-reverse;
   align-items: baseline;
   gap: 32px;
+
+  @media ${QUERIES.tabletAndSmaller} {
+    flex-direction: column-reverse;
+    gap: 0px;
+  }
 `;
 
-const LeftColumn = styled.div`
+const Nav = styled.div`
   flex-basis: 248px;
+
+  @media ${QUERIES.tabletAndSmaller} {
+    flex-basis: 0;
+  }
 `;
 
-const MainColumn = styled.div`
+const Main = styled.div`
   flex: 1;
 `;
 
@@ -66,6 +77,12 @@ const Header = styled.header`
 const Title = styled.h2`
   font-size: 1.5rem;
   font-weight: ${WEIGHTS.medium};
+`;
+
+const AdditionalNavigation = styled.div`
+  @media ${QUERIES.tabletAndSmaller} {
+    display: none;
+  }
 `;
 
 export default ShoeIndex;

--- a/src/components/ShoeIndex/ShoeIndex.js
+++ b/src/components/ShoeIndex/ShoeIndex.js
@@ -15,14 +15,14 @@ const ShoeIndex = ({ sortId, setSortId }) => {
       <Main>
         <Header>
           <Title>Running</Title>
-          <Select
+          <SelectHiddenOnMobile
             label="Sort"
             value={sortId}
             onChange={(ev) => setSortId(ev.target.value)}
           >
             <option value="newest">Newest Releases</option>
             <option value="price">Price</option>
-          </Select>
+          </SelectHiddenOnMobile>
         </Header>
         <Spacer size={32} />
         <ShoeGrid />
@@ -91,6 +91,12 @@ const Header = styled.header`
 const Title = styled.h2`
   font-size: 1.5rem;
   font-weight: ${WEIGHTS.medium};
+`;
+
+const SelectHiddenOnMobile = styled(Select)`
+  @media ${QUERIES.phoneAndSmaller} {
+    display: none;
+  }
 `;
 
 export default ShoeIndex;

--- a/src/components/ShoeIndex/ShoeIndex.js
+++ b/src/components/ShoeIndex/ShoeIndex.js
@@ -27,22 +27,28 @@ const ShoeIndex = ({ sortId, setSortId }) => {
         <Spacer size={32} />
         <ShoeGrid />
       </Main>
-      <Nav>
-        <Breadcrumbs>
-          <Breadcrumbs.Crumb href="/">Home</Breadcrumbs.Crumb>
-          <Breadcrumbs.Crumb href="/sale">Sale</Breadcrumbs.Crumb>
-          <Breadcrumbs.Crumb href="/sale/shoes">
-            Shoes
-          </Breadcrumbs.Crumb>
-        </Breadcrumbs>
-        <AdditionalNavigation>
-          <Spacer size={42} />
-          <ShoeSidebar />
-        </AdditionalNavigation>
-      </Nav>
+
+      <DesktopNav>
+        <BreadcrumbsInIndex />
+        <Spacer size={42} />
+        <ShoeSidebar />
+      </DesktopNav>
+
+      <MobileNav>
+        <BreadcrumbsInIndex />
+      </MobileNav>
     </Wrapper>
   );
 };
+
+const BreadcrumbsInIndex = () =>
+  <Breadcrumbs>
+    <Breadcrumbs.Crumb href="/">Home</Breadcrumbs.Crumb>
+    <Breadcrumbs.Crumb href="/sale">Sale</Breadcrumbs.Crumb>
+    <Breadcrumbs.Crumb href="/sale/shoes">
+      Shoes
+    </Breadcrumbs.Crumb>
+  </Breadcrumbs>
 
 const Wrapper = styled.div`
   display: flex;
@@ -56,11 +62,19 @@ const Wrapper = styled.div`
   }
 `;
 
-const Nav = styled.div`
+const DesktopNav = styled.div`
   flex-basis: 248px;
 
   @media ${QUERIES.tabletAndSmaller} {
-    flex-basis: 0;
+    display: none;
+  }
+`;
+
+const MobileNav = styled.div`
+  display: none;
+
+  @media ${QUERIES.tabletAndSmaller} {
+    display: revert;
   }
 `;
 
@@ -77,12 +91,6 @@ const Header = styled.header`
 const Title = styled.h2`
   font-size: 1.5rem;
   font-weight: ${WEIGHTS.medium};
-`;
-
-const AdditionalNavigation = styled.div`
-  @media ${QUERIES.tabletAndSmaller} {
-    display: none;
-  }
 `;
 
 export default ShoeIndex;


### PR DESCRIPTION
Submission for [Exercise 3](https://github.com/VrsajkovIvan33/sole-and-ankle-revisited?tab=readme-ov-file#exercise-3-tweaks-to-our-main-view).

- Rename components in shoe index to not refer to "columns".
- Add mobile navigation that only has the breadcrumbs and shows above the main shoes component.
- Adjust padding for mobile on shoe index.
- Make Select disappear when on mobile.

Opted to duplicate the breadcrumbs to avoid butchering the ~~LeftColumn~~ DesktopNavigation component with partial hiding of content and overwriting or refactoring use of `flex-basis`.