### PR TITLE
Mobile menu

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -86,23 +86,23 @@ const SmallScreenMainHeader = styled.div`
 `;
 
 const Nav = styled.nav`
-display: flex;
-gap: 48px;
-margin: 0px 48px;
+  display: flex;
+  gap: 48px;
+  margin: 0px 48px;
 `;
 
 const Side = styled.div`
-flex: 1;
+  flex: 1;
 `;
 
 const NavLink = styled.a`
-font - size: 1.125rem;
-text - transform: uppercase;
-text - decoration: none;
-color: ${COLORS.gray[900]};
-font - weight: ${WEIGHTS.medium};
+  font-size: 1.125rem;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: ${COLORS.gray[900]};
+  font-weight: ${WEIGHTS.medium};
 
-  &: first - of - type {
+  &: first-of-type {
   color: ${COLORS.secondary};
 }
 `;

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -17,7 +17,10 @@ const MobileMenu = ({ isOpen, onDismiss }) => {
   return (
     <Overlay isOpen={isOpen} onDismiss={onDismiss}>
       <Content>
-        <button onClick={onDismiss}>Dismiss menu</button>
+        <CloseButton onClick={onDismiss}>
+          <Icon id={"close"} size={24} />
+          <VisuallyHidden>Dismiss menu</VisuallyHidden>
+        </CloseButton>
         <FlexFiller />
         <DialogNav>
           <a href="/sale">Sale</a>
@@ -61,6 +64,8 @@ const Content = styled(DialogContent)`
   background-color: ${COLORS.white};
 
   padding: 32px;
+
+  position: relative;
 `;
 
 const DialogNav = styled.nav`
@@ -78,6 +83,12 @@ const DialogFooter = styled.footer`
 
 const FlexFiller = styled.div`
   flex: 1;
+`;
+
+const CloseButton = styled(UnstyledButton)`
+  position: absolute;
+  top: 24px;
+  right: 16px;
 `;
 
 export default MobileMenu;

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -23,12 +23,12 @@ const MobileMenu = ({ isOpen, onDismiss }) => {
         </CloseButton>
         <FlexFiller />
         <DialogNav>
-          <a href="/sale">Sale</a>
-          <a href="/new">New&nbsp;Releases</a>
-          <a href="/men">Men</a>
-          <a href="/women">Women</a>
-          <a href="/kids">Kids</a>
-          <a href="/collections">Collections</a>
+          <NavLink href="/sale">Sale</NavLink>
+          <NavLink href="/new">New&nbsp;Releases</NavLink>
+          <NavLink href="/men">Men</NavLink>
+          <NavLink href="/women">Women</NavLink>
+          <NavLink href="/kids">Kids</NavLink>
+          <NavLink href="/collections">Collections</NavLink>
         </DialogNav>
         <FlexFiller>
           <DialogFooter>
@@ -71,6 +71,7 @@ const Content = styled(DialogContent)`
 const DialogNav = styled.nav`
   display: flex;
   flex-direction: column;
+  gap: 16px;
 `;
 
 const DialogFooter = styled.footer`
@@ -89,6 +90,18 @@ const CloseButton = styled(UnstyledButton)`
   position: absolute;
   top: 24px;
   right: 16px;
+`;
+
+const NavLink = styled.a`
+  font-size: 1.125rem;
+  text-transform: uppercase;
+  text-decoration: none;
+  color: ${COLORS.gray[900]};
+  font-weight: ${WEIGHTS.medium};
+
+  &: first-of-type {
+    color: ${COLORS.secondary};
+}
 `;
 
 export default MobileMenu;

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -58,7 +58,7 @@ const Content = styled(DialogContent)`
   display: flex;
   flex-direction: column;
 
-  background-color: white;
+  background-color: ${COLORS.white};
 
   padding: 32px;
 `;
@@ -70,7 +70,7 @@ const DialogNav = styled.nav`
 
 const DialogFooter = styled.footer`
   height: 100%;
-  
+
   display: flex;
   flex-direction: column;
   justify-content: flex-end;

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -32,9 +32,9 @@ const MobileMenu = ({ isOpen, onDismiss }) => {
         </DialogNav>
         <FlexFiller>
           <DialogFooter>
-            <a href="/terms">Terms and Conditions</a>
-            <a href="/privacy">Privacy Policy</a>
-            <a href="/contact">Contact Us</a>
+            <UtiliyLink href="/terms">Terms and Conditions</UtiliyLink>
+            <UtiliyLink href="/privacy">Privacy Policy</UtiliyLink>
+            <UtiliyLink href="/contact">Contact Us</UtiliyLink>
           </DialogFooter>
         </FlexFiller>
       </Content>
@@ -80,6 +80,7 @@ const DialogFooter = styled.footer`
   display: flex;
   flex-direction: column;
   justify-content: flex-end;
+  gap: 8px;
 `;
 
 const FlexFiller = styled.div`
@@ -101,7 +102,14 @@ const NavLink = styled.a`
 
   &: first-of-type {
     color: ${COLORS.secondary};
-}
+  }
+`;
+
+const UtiliyLink = styled.a`
+  font-size: 0.875rem;
+  text-decoration: none;
+  color: ${COLORS.gray[700]};
+  font-weight: ${WEIGHTS.normal};
 `;
 
 export default MobileMenu;

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -18,6 +18,7 @@ const MobileMenu = ({ isOpen, onDismiss }) => {
     <Overlay isOpen={isOpen} onDismiss={onDismiss}>
       <Content>
         <button onClick={onDismiss}>Dismiss menu</button>
+        <FlexFiller />
         <DialogNav>
           <a href="/sale">Sale</a>
           <a href="/new">New&nbsp;Releases</a>
@@ -26,35 +27,15 @@ const MobileMenu = ({ isOpen, onDismiss }) => {
           <a href="/kids">Kids</a>
           <a href="/collections">Collections</a>
         </DialogNav>
-        <DialogFooter>
-          <a href="/terms">Terms and Conditions</a>
-          <a href="/privacy">Privacy Policy</a>
-          <a href="/contact">Contact Us</a>
-        </DialogFooter>
+        <FlexFiller>
+          <DialogFooter>
+            <a href="/terms">Terms and Conditions</a>
+            <a href="/privacy">Privacy Policy</a>
+            <a href="/contact">Contact Us</a>
+          </DialogFooter>
+        </FlexFiller>
       </Content>
     </Overlay >
-    // <Overlay isOpen={isOpen} onDismiss={onDismiss}>
-    //   <Content aria-label="Menu">
-    //     <CloseButton onClick={onDismiss}>
-    //       <Icon id="close" />
-    //       <VisuallyHidden>Dismiss menu</VisuallyHidden>
-    //     </CloseButton>
-    //     <Filler />
-    //     <Nav>
-    //       <NavLink href="/sale">Sale</NavLink>
-    //       <NavLink href="/new">New&nbsp;Releases</NavLink>
-    //       <NavLink href="/men">Men</NavLink>
-    //       <NavLink href="/women">Women</NavLink>
-    //       <NavLink href="/kids">Kids</NavLink>
-    //       <NavLink href="/collections">Collections</NavLink>
-    //     </Nav>
-    //     <Footer>
-    //       <a href="/terms">Terms and Conditions</a>
-    //       <a href="/privacy">Privacy Policy</a>
-    //       <a href="/contact">Contact Us</a>
-    //     </Footer>
-    //   </Content>
-    // </Overlay>
   );
 };
 
@@ -78,6 +59,8 @@ const Content = styled(DialogContent)`
   flex-direction: column;
 
   background-color: white;
+
+  padding: 32px;
 `;
 
 const DialogNav = styled.nav`
@@ -86,8 +69,15 @@ const DialogNav = styled.nav`
 `;
 
 const DialogFooter = styled.footer`
+  height: 100%;
+  
   display: flex;
   flex-direction: column;
+  justify-content: flex-end;
+`;
+
+const FlexFiller = styled.div`
+  flex: 1;
 `;
 
 export default MobileMenu;

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -7,40 +7,77 @@ import UnstyledButton from '../UnstyledButton';
 import Icon from '../Icon';
 import VisuallyHidden from '../VisuallyHidden';
 
+import { COLORS, WEIGHTS } from '../../constants';
+
 const MobileMenu = ({ isOpen, onDismiss }) => {
-  if (!isOpen) {
-    return null;
-  }
+  // if (!isOpen) {
+  //   return null;
+  // }
 
   return (
-    <DialogOverlay>
-      <DialogContent>
-        <DialogLayout>
-          <button onClick={onDismiss}>Dismiss menu</button>
-          <DialogNav>
-            <a href="/sale">Sale</a>
-            <a href="/new">New&nbsp;Releases</a>
-            <a href="/men">Men</a>
-            <a href="/women">Women</a>
-            <a href="/kids">Kids</a>
-            <a href="/collections">Collections</a>
-          </DialogNav>
-          <DialogFooter>
-            <a href="/terms">Terms and Conditions</a>
-            <a href="/privacy">Privacy Policy</a>
-            <a href="/contact">Contact Us</a>
-          </DialogFooter>
-        </DialogLayout>
-      </DialogContent>
-    </DialogOverlay >
+    <Overlay isOpen={isOpen} onDismiss={onDismiss}>
+      <Content>
+        <button onClick={onDismiss}>Dismiss menu</button>
+        <DialogNav>
+          <a href="/sale">Sale</a>
+          <a href="/new">New&nbsp;Releases</a>
+          <a href="/men">Men</a>
+          <a href="/women">Women</a>
+          <a href="/kids">Kids</a>
+          <a href="/collections">Collections</a>
+        </DialogNav>
+        <DialogFooter>
+          <a href="/terms">Terms and Conditions</a>
+          <a href="/privacy">Privacy Policy</a>
+          <a href="/contact">Contact Us</a>
+        </DialogFooter>
+      </Content>
+    </Overlay >
+    // <Overlay isOpen={isOpen} onDismiss={onDismiss}>
+    //   <Content aria-label="Menu">
+    //     <CloseButton onClick={onDismiss}>
+    //       <Icon id="close" />
+    //       <VisuallyHidden>Dismiss menu</VisuallyHidden>
+    //     </CloseButton>
+    //     <Filler />
+    //     <Nav>
+    //       <NavLink href="/sale">Sale</NavLink>
+    //       <NavLink href="/new">New&nbsp;Releases</NavLink>
+    //       <NavLink href="/men">Men</NavLink>
+    //       <NavLink href="/women">Women</NavLink>
+    //       <NavLink href="/kids">Kids</NavLink>
+    //       <NavLink href="/collections">Collections</NavLink>
+    //     </Nav>
+    //     <Footer>
+    //       <a href="/terms">Terms and Conditions</a>
+    //       <a href="/privacy">Privacy Policy</a>
+    //       <a href="/contact">Contact Us</a>
+    //     </Footer>
+    //   </Content>
+    // </Overlay>
   );
 };
 
-const DialogLayout = styled.div`
+const Overlay = styled(DialogOverlay)`
+  position: fixed;
+
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+
+  background-color: hsl(220deg 5% 40% / 0.8);
+`;
+
+const Content = styled(DialogContent)`
   height: 100%;
-  background-color: white;
+  width: 80%;
+  margin-left: auto;
+
   display: flex;
   flex-direction: column;
+
+  background-color: white;
 `;
 
 const DialogNav = styled.nav`

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -10,10 +10,6 @@ import VisuallyHidden from '../VisuallyHidden';
 import { COLORS, WEIGHTS } from '../../constants';
 
 const MobileMenu = ({ isOpen, onDismiss }) => {
-  // if (!isOpen) {
-  //   return null;
-  // }
-
   return (
     <Overlay isOpen={isOpen} onDismiss={onDismiss}>
       <Content>


### PR DESCRIPTION
Submission for [Exercise 4](https://github.com/VrsajkovIvan33/sole-and-ankle-revisited?tab=readme-ov-file#exercise-4-mobile-menu).

Fix the dialog added in the submission for Exercise 1. The Reach UI dialog is style-less, it uses flow layout by default. Some elements in the shoe grid use positioned layout, making them appear over the original dialog implementation and causing confustion.

Set up the rest of the mobile menu to match the specifications provided in Figma.