### PR TITLE
Fluid header

### DIFF
--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -87,7 +87,7 @@ const SmallScreenMainHeader = styled.div`
 
 const Nav = styled.nav`
   display: flex;
-  gap: 48px;
+  gap: clamp(1.5rem, 5vw - 1.5rem, 3rem);
   margin: 0px 48px;
 `;
 

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -62,6 +62,8 @@ const MainHeader = styled.div`
   height: 72px;
   border-bottom: 1px solid ${COLORS.gray[300]};
 
+  overflow: scroll;
+
   @media ${QUERIES.tabletAndSmaller} {
     display: none;
   }


### PR DESCRIPTION
Submission for [Exercise 5](https://github.com/VrsajkovIvan33/sole-and-ankle-revisited?tab=readme-ov-file#exercise-5-fluid-desktop-navigation).

- Remove the static spacing between the entries in the header's navigation, make it dynamic.
- Add scroll on overflow if we lose space before the media query kicks in.