### PR TITLE
Colors as CSS variables

### DIFF
--- a/src/components/Breadcrumbs/Breadcrumbs.js
+++ b/src/components/Breadcrumbs/Breadcrumbs.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import styled from 'styled-components/macro';
-import { COLORS } from '../../constants';
 
 const Breadcrumbs = ({ children }) => {
   return <Wrapper>{children}</Wrapper>;
@@ -23,17 +22,17 @@ const CrumbWrapper = styled.div`
     &::before {
       content: '/';
       margin-right: 8px;
-      color: ${COLORS.gray[300]};
+      color: var(--color-grey-300);
     }
   }
 `;
 
 const CrumbLink = styled.a`
-  color: ${COLORS.gray[700]};
+  color: var(--color-grey-700);
   text-decoration: none;
 
   &:hover {
-    color: ${COLORS.gray[900]};
+    color: var(--color-grey-900);
   }
 `;
 

--- a/src/components/GlobalStyles/GlobalStyles.js
+++ b/src/components/GlobalStyles/GlobalStyles.js
@@ -64,6 +64,15 @@ table {
     float above the app.
   */
   isolation: isolate;
+
+  --color-white: hsl(0deg 0% 100%);
+  --color-grey-100: hsl(185deg 5% 95%);
+  --color-grey-300: hsl(190deg 5% 80%);
+  --color-grey-500: hsl(196deg 4% 60%);
+  --color-grey-700: hsl(220deg 5% 40%);
+  --color-grey-900: hsl(220deg 3% 20%);
+  --color-primary: hsl(340deg 65% 47%);
+  --color-secondary: hsl(240deg 60% 63%);
 }
 
 html {

--- a/src/components/GlobalStyles/GlobalStyles.js
+++ b/src/components/GlobalStyles/GlobalStyles.js
@@ -64,6 +64,13 @@ table {
     float above the app.
   */
   isolation: isolate;
+}
+
+html {
+  /*
+    Silence the warning about missing Reach Dialog styles
+  */
+  --reach-dialog: 1;
 
   --white: 0deg 0% 100%;
   --grey-100: 185deg 5% 95%;
@@ -82,13 +89,6 @@ table {
   --color-grey-900: hsl(var(--grey-900));
   --color-primary: hsl(var(--primary));
   --color-secondary: hsl(var(--secondary));
-}
-
-html {
-  /*
-    Silence the warning about missing Reach Dialog styles
-  */
-  --reach-dialog: 1;
 }
 
 html, body, #root {

--- a/src/components/GlobalStyles/GlobalStyles.js
+++ b/src/components/GlobalStyles/GlobalStyles.js
@@ -65,14 +65,23 @@ table {
   */
   isolation: isolate;
 
-  --color-white: hsl(0deg 0% 100%);
-  --color-grey-100: hsl(185deg 5% 95%);
-  --color-grey-300: hsl(190deg 5% 80%);
-  --color-grey-500: hsl(196deg 4% 60%);
-  --color-grey-700: hsl(220deg 5% 40%);
-  --color-grey-900: hsl(220deg 3% 20%);
-  --color-primary: hsl(340deg 65% 47%);
-  --color-secondary: hsl(240deg 60% 63%);
+  --white: 0deg 0% 100%;
+  --grey-100: 185deg 5% 95%;
+  --grey-300: 190deg 5% 80%;
+  --grey-500: 196deg 4% 60%;
+  --grey-700: 220deg 5% 40%;
+  --grey-900: 220deg 3% 20%;
+  --primary: 340deg 65% 47%;
+  --secondary: 240deg 60% 63%;
+
+  --color-white: hsl(var(--white));
+  --color-grey-100: hsl(var(--grey-100));
+  --color-grey-300: hsl(var(--grey-300));
+  --color-grey-500: hsl(var(--grey-500));
+  --color-grey-700: hsl(var(--grey-700));
+  --color-grey-900: hsl(var(--grey-900));
+  --color-primary: hsl(var(--primary));
+  --color-secondary: hsl(var(--secondary));
 }
 
 html {

--- a/src/components/Header/Header.js
+++ b/src/components/Header/Header.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS, WEIGHTS, QUERIES } from '../../constants';
+import { WEIGHTS, QUERIES } from '../../constants';
 import Logo from '../Logo';
 import SuperHeader from '../SuperHeader';
 import MobileMenu from '../MobileMenu';
@@ -60,7 +60,7 @@ const MainHeader = styled.div`
   align-items: baseline;
   padding: 18px 32px;
   height: 72px;
-  border-bottom: 1px solid ${COLORS.gray[300]};
+  border-bottom: 1px solid var(--color-grey-300);
 
   overflow: scroll;
 
@@ -74,8 +74,10 @@ const SmallScreenMainHeader = styled.div`
 
   padding: 18px 32px;
   height: 72px;
-  border-top: 4px solid ${COLORS.gray[900]};
-  border-bottom: 1px solid ${COLORS.gray[300]};
+  border-top: 4px solid var(--color-grey-900);
+  border-bottom: 1px solid var(--color-grey-300);
+  border-top: 4px solid var(--color-grey-900);
+  border-bottom: 1px solid var(--color-grey-300);
 
   @media ${QUERIES.tabletAndSmaller} {
     display: flex;
@@ -101,12 +103,12 @@ const NavLink = styled.a`
   font-size: 1.125rem;
   text-transform: uppercase;
   text-decoration: none;
-  color: ${COLORS.gray[900]};
+  color: var(--color-grey-900);
   font-weight: ${WEIGHTS.medium};
 
   &: first-of-type {
-  color: ${COLORS.secondary};
-}
+    color: var(--color-secondary);
+  }
 `;
 
 export default Header;

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -7,7 +7,7 @@ import UnstyledButton from '../UnstyledButton';
 import Icon from '../Icon';
 import VisuallyHidden from '../VisuallyHidden';
 
-import { COLORS, WEIGHTS } from '../../constants';
+import { WEIGHTS } from '../../constants';
 
 const MobileMenu = ({ isOpen, onDismiss }) => {
   return (
@@ -57,7 +57,7 @@ const Content = styled(DialogContent)`
   display: flex;
   flex-direction: column;
 
-  background-color: ${COLORS.white};
+  background-color: var(--color-white);
 
   padding: 32px;
 
@@ -93,18 +93,18 @@ const NavLink = styled.a`
   font-size: 1.125rem;
   text-transform: uppercase;
   text-decoration: none;
-  color: ${COLORS.gray[900]};
+  color: var(--color-grey-900);
   font-weight: ${WEIGHTS.medium};
 
   &: first-of-type {
-    color: ${COLORS.secondary};
+    color: var(--color-secondary);
   }
 `;
 
 const UtiliyLink = styled.a`
   font-size: 0.875rem;
   text-decoration: none;
-  color: ${COLORS.gray[700]};
+  color: var(--color-grey-700);
   font-weight: ${WEIGHTS.normal};
 `;
 

--- a/src/components/MobileMenu/MobileMenu.js
+++ b/src/components/MobileMenu/MobileMenu.js
@@ -46,7 +46,7 @@ const Overlay = styled(DialogOverlay)`
   right: 0;
   bottom: 0;
 
-  background-color: hsl(220deg 5% 40% / 0.8);
+  background-color: hsl(var(--grey-700) / 0.8);
 `;
 
 const Content = styled(DialogContent)`

--- a/src/components/SearchInput/SearchInput.js
+++ b/src/components/SearchInput/SearchInput.js
@@ -1,8 +1,6 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS } from '../../constants';
-
 import VisuallyHidden from '../VisuallyHidden';
 import Icon from '../Icon';
 
@@ -23,14 +21,14 @@ const Label = styled.label`
 const Input = styled.input`
   border: none;
   background: transparent;
-  border-bottom: 1px solid ${COLORS.gray[300]};
+  border-bottom: 1px solid var(--color-grey-300);
   padding-left: 24px;
   font-size: 0.875rem;
-  color: ${COLORS.gray[100]};
+  color: --var(color-grey-100);
   outline-offset: 4px;
 
   &::placeholder {
-    color: ${COLORS.gray[500]};
+    color: var(--color-grey-500);
   }
 `;
 

--- a/src/components/Select/Select.js
+++ b/src/components/Select/Select.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS, WEIGHTS } from '../../constants';
+import { WEIGHTS } from '../../constants';
 
 import Icon from '../Icon';
 
@@ -39,7 +39,7 @@ const Wrapper = styled.label`
 `;
 
 const VisibleLabel = styled.span`
-  color: ${COLORS.gray[700]};
+  color: --var(color-grey-700);
   margin-right: 16px;
 `;
 
@@ -61,10 +61,10 @@ const NativeSelect = styled.select`
 
 const DisplayedBit = styled.span`
   display: block;
-  background: ${COLORS.gray[100]};
+  background: var(--color-grey-100);
   font-size: 1rem;
   font-weight: ${WEIGHTS.medium};
-  color: ${COLORS.gray[900]};
+  color: --var(color-grey-900);
   padding: 12px 42px 12px 16px;
   border-radius: 8px;
   pointer-events: none;

--- a/src/components/ShoeCard/ShoeCard.js
+++ b/src/components/ShoeCard/ShoeCard.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS, WEIGHTS } from '../../constants';
+import { WEIGHTS } from '../../constants';
 import { formatPrice, pluralize, isNewShoe } from '../../utils';
 import Spacer from '../Spacer';
 
@@ -47,7 +47,7 @@ const ShoeCard = ({
           <Price
             style={{
               '--color':
-                variant === 'on-sale' ? COLORS.gray[700] : undefined,
+                variant === 'on-sale' ? 'var(--color-grey-700)' : undefined,
               '--text-decoration':
                 variant === 'on-sale' ? 'line-through' : undefined,
             }}
@@ -90,7 +90,7 @@ const Row = styled.div`
 
 const Name = styled.h3`
   font-weight: ${WEIGHTS.medium};
-  color: ${COLORS.gray[900]};
+  color: var(--color-grey-900);
 `;
 
 const Price = styled.span`
@@ -99,12 +99,12 @@ const Price = styled.span`
 `;
 
 const ColorInfo = styled.p`
-  color: ${COLORS.gray[700]};
+  color: var(--color-grey-700);
 `;
 
 const SalePrice = styled.span`
   font-weight: ${WEIGHTS.medium};
-  color: ${COLORS.primary};
+  color: var(--color-primary);
 `;
 
 const Flag = styled.div`
@@ -117,15 +117,15 @@ const Flag = styled.div`
   padding: 0 10px;
   font-size: ${14 / 18}rem;
   font-weight: ${WEIGHTS.bold};
-  color: ${COLORS.white};
+  color: var(--color-white);
   border-radius: 2px;
 `;
 
 const SaleFlag = styled(Flag)`
-  background-color: ${COLORS.primary};
+  background-color: var(--color-primary);
 `;
 const NewFlag = styled(Flag)`
-  background-color: ${COLORS.secondary};
+  background-color: var(--color-secondary);
 `;
 
 export default ShoeCard;

--- a/src/components/ShoeSidebar/ShoeSidebar.js
+++ b/src/components/ShoeSidebar/ShoeSidebar.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS, WEIGHTS } from '../../constants';
+import { WEIGHTS } from '../../constants';
 
 const Sidebar = () => {
   return (
@@ -29,12 +29,12 @@ const Link = styled.a`
   display: block;
   text-decoration: none;
   font-weight: ${WEIGHTS.medium};
-  color: ${COLORS.gray[900]};
+  color: var(--color-grey-900);
   line-height: 2;
 `;
 
 const ActiveLink = styled(Link)`
-  color: ${COLORS.primary};
+  color: var(--color-primary)
 `;
 
 export default Sidebar;

--- a/src/components/SuperHeader/SuperHeader.js
+++ b/src/components/SuperHeader/SuperHeader.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import styled from 'styled-components/macro';
 
-import { COLORS, QUERIES } from '../../constants';
+import { QUERIES } from '../../constants';
 
 import SearchInput from '../SearchInput';
 import UnstyledButton from '../UnstyledButton';
@@ -27,8 +27,8 @@ const Wrapper = styled.div`
   align-items: center;
   gap: 24px;
   font-size: 0.875rem;
-  color: ${COLORS.gray[300]};
-  background-color: ${COLORS.gray[900]};
+  color: var(--color-grey-300);
+  background-color: var(--color-grey-900);
   height: 40px;
   padding-left: 32px;
   padding-right: 32px;
@@ -39,7 +39,7 @@ const Wrapper = styled.div`
 `;
 
 const MarketingMessage = styled.span`
-  color: ${COLORS.white};
+  color: var(--color-white);
   margin-right: auto;
 `;
 

--- a/src/constants.js
+++ b/src/constants.js
@@ -1,16 +1,3 @@
-export const COLORS = {
-  white: 'hsl(0deg 0% 100%)',
-  gray: {
-    100: 'hsl(185deg 5% 95%)',
-    300: 'hsl(190deg 5% 80%)',
-    500: 'hsl(196deg 4% 60%)',
-    700: 'hsl(220deg 5% 40%)',
-    900: 'hsl(220deg 3% 20%)',
-  },
-  primary: 'hsl(340deg 65% 47%)',
-  secondary: 'hsl(240deg 60% 63%)',
-};
-
 export const WEIGHTS = {
   normal: 500,
   medium: 600,


### PR DESCRIPTION
Submission for [Excercise 6](https://github.com/VrsajkovIvan33/sole-and-ankle-revisited?tab=readme-ov-file#exercise-6-theming-with-css-variables).

- Define all the colors as CSS variables under `html`.
- Replace the usage of the `COLORS` object.
- Remove `COLORS`.
- Define modal backdrop using CSS vars, supplying the hue, saturation and lightness.

Note: The color CSS vars go under `html` and not `#root` because, otherwise, they are not available in the dialog using portals that is defined _outside_ of the root div.